### PR TITLE
Fix argument parsing logic

### DIFF
--- a/statica
+++ b/statica
@@ -6,7 +6,7 @@ usage() {
   exit 1
 }
 
-if [ $# -lt 1 ]; then
+if [ $# -lt 2 ]; then
   usage
 fi
 


### PR DESCRIPTION
Prior to this change statica would run with no `console` or `html` output specified, resulting in the scans running but no output being returned to the user. For example:

```
./statica ~/src/test
```

Would successfully execute but produce no output.