### PR TITLE
Fix CI Homebrew failures, bump to 1.2.8, harden release.sh

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -29,5 +29,8 @@ jobs:
 
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          # The runner image pins an old Homebrew and disables auto-update, which
+          # cannot parse current homebrew-core formulae ("unknown install step").
+          brew update
           brew install actionlint
           make test

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ WebGoat
 /experimental.d/
 .prisma.*
 .DS_Store
+
+# built gems
+*.gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    statica (0.1.0)
+    statica (1.2.8)
       csv (~> 3.3)
       ostruct (~> 0.6)
 

--- a/acceptance.sh
+++ b/acceptance.sh
@@ -11,6 +11,10 @@ set -euo pipefail
 # formulae (Errno::EINVAL @ apply2files) on GitHub runners
 export HOMEBREW_NO_SANDBOX_LINUX=1
 
+# The runner image pins an old Homebrew and disables auto-update, which cannot
+# parse current homebrew-core formulae ("unknown install step: ...")
+brew update
+
 brew install semgrep \
     jq \
     retire \

--- a/live.sh
+++ b/live.sh
@@ -10,6 +10,10 @@ set -euo pipefail
 # formulae (Errno::EINVAL @ apply2files) on GitHub runners
 export HOMEBREW_NO_SANDBOX_LINUX=1
 
+# The runner image pins an old Homebrew and disables auto-update, which cannot
+# parse current homebrew-core formulae ("unknown install step: ...")
+brew update
+
 brew install simpsonjulian/statica-tap/statica bearer/tap/bearer
 
 TEMP=$(mktemp -d)

--- a/release.sh
+++ b/release.sh
@@ -10,17 +10,37 @@ fi
 
 set -euo pipefail
 
+# Releasing from a feature branch pushes the bump there while `gh release
+# create` still tags the default branch, leaving the tag without the bump
+branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$branch" != "main" ]; then
+    echo "Refusing to release from '${branch}'; switch to main first." >&2
+    exit 1
+fi
+
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+    echo "Working tree has uncommitted changes; commit or stash first." >&2
+    exit 1
+fi
+
 # Update version in gemspec
 new_version_line="spec.version       = \"$version\""
 sed -i '' "s/spec.version.*=.*/${new_version_line}/" statica.gemspec
 
-# Build and commit the gem
+# Gemfile.lock pins the gemspec version, so a stale lock fails the frozen
+# `bundle install --deployment` that CI runs
+bundle install
+
+# Build to validate the gemspec, but keep the artifact out of the repo
 gem build statica.gemspec
-git add statica.gemspec statica-"$version".gem
+rm -f statica-"$version".gem
+
+git add statica.gemspec Gemfile.lock
 git commit -m "Bump version to ${version}"
 git push
 
-# Create GitHub release and update Homebrew
+# Create GitHub release and update Homebrew. --target pins the tag to the
+# commit just pushed rather than whatever the default branch happens to be.
 brew update
-gh release create v"$version" --generate-notes
-brew bump-formula-pr --version "$version" statica
+gh release create v"$version" --target "$(git rev-parse HEAD)" --generate-notes
+brew bump-formula-pr --version "$version" --no-fork simpsonjulian/statica-tap/statica

--- a/statica.gemspec
+++ b/statica.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'statica'
-  spec.version       = '0.1.0'
+  spec.version       = '1.2.8'
   spec.authors       = ['simpsonjulian']
   spec.email         = ['simpsonjulian@gmail.com']
 


### PR DESCRIPTION
## Homebrew failures

Three workflows broke when the `ubuntu-22.04` runner image moved from `20260720.234` to `20260726.241`:

| Workflow | Error |
|---|---|
| Linting and Specs | `unknown install step: configure_gcc_runtime` (actionlint → gcc) |
| Acceptance Tests | `unknown install step: remove` (semgrep deps) |
| Live Tests | same |

The runner images pin a Homebrew revision and set `HOMEBREW_NO_AUTO_UPDATE=1`, so that Homebrew can no longer parse current homebrew-core formulae. Homebrew's own output says what to do:

> You have disabled automatic updates and have not updated today.
> Do not report this issue until you've run `brew update` and tried again.

So `brew update` now runs before `brew install` in `spec.yml`, `acceptance.sh` and `live.sh`.

## Version bump

`release.sh` was run from a feature branch during triage. `git push` put the bump on that branch while `gh release create` tagged the default branch HEAD, so the published `v1.2.7` tag does not contain its own version bump. Rather than re-cut a published tag, this goes to 1.2.8.

The same run rewrote `statica.gemspec` without regenerating `Gemfile.lock`, which still pinned `statica (0.1.0)`. That failed CI's frozen `bundle install --deployment`. The lock is regenerated here.

## release.sh

Guarded against each failure mode above:

- refuse to run off `main`, or with a dirty working tree
- regenerate `Gemfile.lock` after rewriting the gemspec
- build the gem to validate the gemspec, but don't commit the artifact (`*.gem` is now gitignored)
- pass `--target` so the tag lands on the commit just pushed
- qualify `brew bump-formula-pr` with the tap — bare `statica` matched nothing, which is why the tap is still on v1.2.6

## Still outstanding

Live Tests on `macos-latest` needs the tap formula moved to v1.2.8; v1.2.6's Gemfile pulls `gruff` → `rmagick`, which fails to build. That's a change to `simpsonjulian/homebrew-statica-tap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)