### PR TITLE
Add a git topology analyser

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,116 @@ Statica uses graph analysis (via the RGL library) to identify patterns in findin
 
 The graph structure follows: `(analysis)-[:HAS]->(finding)-[:IN]->(file)`
 
+### Branching topology
+
+The `topology` analyser reports on the health of the branching workflow rather than the code:
+branches that never merge back, changes stranded on a release line, and merges that were
+expensive because the branches were allowed to drift.
+
+It has no opinion on gitflow versus trunk-based development. It reports facts about the commit
+graph and leaves the judgement to you.
+
+It is strictly read-only — everything is computed from `for-each-ref`, `rev-list`, `merge-base`,
+`diff` and `patch-id`. It never checks out, merges, fetches, or touches the index, so it is safe
+to run against a repository you are working in.
+
+#### Requirements
+
+The analyser needs real history. It requires no tools beyond `git`, but:
+
+- **Source with no `.git` at all** — the common case when code arrives as an archive — is not an
+  error. The analyser contributes nothing and says nothing.
+- **Shallow and partial clones are skipped**, with a single diagnostic on stderr. A shallow clone
+  has no merge bases, so every branch would look unmerged and every finding would be wrong. It is
+  better to report nothing than to report confidently wrong things.
+- **In CI this matters**, because `actions/checkout` defaults to `fetch-depth: 1`. The analyser
+  will skip every check unless you ask for the full history:
+
+  ```yaml
+  - uses: actions/checkout@v5
+    with:
+      fetch-depth: 0
+  ```
+
+Walks are bounded: 12 months of history, at most 1000 merges and 500 branches, and the whole
+analyser abandons its remaining work after 120 seconds. On a partial run it says so on stderr.
+
+#### What it checks
+
+Integration branches are whichever of `main`, `master` and `develop` exist; release lines are
+`release/*` and `hotfix/*`. Branches under `spike/`, `archive/`, `experiment/`, `tmp/`, `wip/`,
+`poc/`, `dependabot/` and `renovate/` are treated as intentional dead ends and never reported as
+unmerged.
+
+##### branch-never-merged
+
+A branch that stopped moving but never landed is either abandoned work nobody deleted, or a change
+someone believes shipped and did not.
+
+Severity scales with how long the branch has been sitting rather than the mere fact it exists —
+nothing under 30 days, `note` from 30, `warning` from 90, `error` from 180. A feature branch a few
+days old is work in progress, not a finding.
+
+Detection is layered, because ancestry alone reports every squash-merged branch as unmerged and
+squash merges are the default on most forges:
+
+1. `merge-base --is-ancestor`, which catches true merges and fast-forwards.
+2. `git cherry`, which catches rebase merges and cherry-picks, where per-commit patch IDs survive.
+3. The branch's cumulative diff patch ID against mainline's commits, which catches squash merges.
+
+Step 3 is not redundant. A squash collapses N commits into one whose patch ID matches none of the
+originals, so `git cherry` alone reports squash-merged branches as unmerged.
+
+##### release-commit-not-forward-ported
+
+A fix applied to a release line and never forward-ported disappears at the next release, and
+typically resurfaces as a reopened bug. One finding per release branch, naming the commits.
+
+Uses `rev-list --cherry-pick`, so commits that reached mainline by cherry-pick rather than merge
+are not reported.
+
+##### merge-high-divergence
+
+Branches that developed in parallel for more than 8 weeks, with at least 5 commits on each side,
+before merging. Both sides have to have genuinely moved — otherwise this fires on a branch that
+simply sat still while mainline advanced, which is `branch-never-merged`'s problem.
+
+The merge is where the pain surfaced; the cost was incurred over the preceding weeks.
+
+##### merge-high-overlap
+
+Files modified on *both* sides of the merge base — the files the merge had to reconcile by hand.
+Reported when at least 10 files overlap and they are at least 25% of the smaller side.
+
+These findings carry real file paths, so they flow into the hotspot table and the graph. A file
+that repeatedly appears in high-overlap merges *and* carries findings from other tools is a
+genuinely useful signal, and that clustering is most of the reason to do this inside Statica.
+
+##### merge-large
+
+Merges integrating at least 100 files or 10,000 changed lines in one step. Informational: the size
+is not a defect, but it bounds how much confidence any review of it could have had.
+
+##### repeated-back-merge
+
+Mainline merged into a branch three or more times before the branch landed. Repeatedly pulling
+mainline in is how a long-lived branch stays merge-able, and a reliable symptom of a branch that
+lived longer than the work justified.
+
+##### criss-cross-merge
+
+Two branches merged into each other in both directions, leaving more than one merge base. Later
+merges between them pick a base ambiguously, and the one git picks may not be the one you would.
+
+##### topology-metrics
+
+One `note` carrying merge-commit ratio, live branch count, mean and p90 branch lifetime, and the
+maximum number of branches in flight at once.
+
+These are context for a human, not defects, and they never fail a build. They are deliberately not
+combined into a composite score — that would be arbitrary, and people would argue with the number
+instead of looking at the inputs.
+
 ### Reports
 
 - **Console Output**: Summary of findings grouped by severity

--- a/graph_analyzer.rb
+++ b/graph_analyzer.rb
@@ -28,17 +28,22 @@ class GraphAnalyzer
     results.each_with_index do |result, idx|
       analysis_node = "analysis:#{result.tool}"
       finding_node = "finding:#{result.rule_id}:#{idx}"
-      file_url = self.class.normalize_file_url(result.file_url, source_root)
-      file_node = "file:#{file_url}"
 
-      # Add nodes with types
       add_node(analysis_node, 'analysis', result.tool)
       add_node(finding_node, 'finding', result.rule_id)
-      add_node(file_node, 'file', file_url)
-
-      # Add edges with types
       add_edge(analysis_node, finding_node, 'HAS')
-      add_edge(finding_node, file_node, 'IN')
+
+      # A finding scoped to a ref rather than a file has no file node to point
+      # at. Hanging it off a synthetic one would inflate that file's finding
+      # count and put it in the hotspot table on the strength of a finding that
+      # was never about a file, so it stays a leaf under its analysis instead.
+      file_url = nil
+      if result.file_url
+        file_url = self.class.normalize_file_url(result.file_url, source_root)
+        file_node = "file:#{file_url}"
+        add_node(file_node, 'file', file_url)
+        add_edge(finding_node, file_node, 'IN')
+      end
 
       # Store finding details
       @finding_details[finding_node] = {

--- a/html_report.rb
+++ b/html_report.rb
@@ -92,17 +92,24 @@ class HtmlReport
 
   def format_result(result, report)
     rule_id = result.rule_id
-    region = result.locations[0].physical_location.region
     run = report.runs.first
     severity = find_severity(result, run)
-    region = region ? region.start_line : 0
-    file_location = result.locations[0].physical_location.artifact_location.uri
+
+    # Not every finding is file-scoped. A finding about a branch or a ref has
+    # nowhere sensible to point in the tree and carries a logicalLocation
+    # instead, so every step down to the physicalLocation has to be optional -
+    # this used to dereference blind, and one such result took down the whole
+    # report rather than just itself.
+    location = result.locations&.first
+    physical = location&.physical_location
+    region = physical&.region
     tool = run.tool.driver.name
 
     OpenStruct.new({ severity: severity,
                      description: CGI.escapeHTML(result.message.text),
-                     linenum: region,
-                     file_url: file_location,
+                     linenum: region ? region.start_line : 0,
+                     file_url: physical&.artifact_location&.uri,
+                     logical_location: location&.logical_locations&.first&.name,
                      rule_id: GraphAnalyzer.clean_rule_id(rule_id),
                      tool: tool })
   end

--- a/spec/fixtures/logical_location.sarif
+++ b/spec/fixtures/logical_location.sarif
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "topology",
+          "version": "2.51.0",
+          "informationUri": "https://github.com/simpsonjulian/statica",
+          "organization": "simpsonjulian",
+          "rules": []
+        }
+      },
+      "results": [
+        {
+          "ruleId": "branch-never-merged",
+          "level": "error",
+          "message": {
+            "text": "Branch 'release/1.8' was last committed to 400 days ago and has never been merged into main."
+          },
+          "locations": [
+            {
+              "logicalLocations": [
+                {
+                  "name": "origin/release/1.8",
+                  "fullyQualifiedName": "origin/release/1.8"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "topology/v1": "branch-never-merged:release/1.8"
+          }
+        },
+        {
+          "ruleId": "merge-high-overlap",
+          "level": "warning",
+          "message": {
+            "text": "Merge abc123def456 had to reconcile 14 files changed on both sides."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/main/java/Payment.java"
+                }
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "topology/v1": "merge-high-overlap:abc123def456"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/spec/graph_analyzer_spec.rb
+++ b/spec/graph_analyzer_spec.rb
@@ -252,4 +252,36 @@ RSpec.describe GraphAnalyzer do
       expect(%w[HAS IN]).to include(edge['label'])
     end
   end
+
+  describe 'findings with no file' do
+    let(:ref_scoped) do
+      OpenStruct.new(
+        tool: 'topology',
+        rule_id: 'branch-never-merged',
+        file_url: nil,
+        severity: 'error',
+        description: 'Branch never merged',
+        linenum: 0
+      )
+    end
+
+    it 'hangs them off their analysis without inventing a file node' do
+      analyzer.analyze([ref_scoped])
+
+      expect(analyzer.graph.vertices).to contain_exactly(
+        'analysis:topology', 'finding:branch-never-merged:0'
+      )
+    end
+
+    # A synthetic file node would put a file nobody touched into the hotspot
+    # table on the strength of a finding that was never about a file.
+    it 'keeps them out of the hotspot counts' do
+      analyzer.analyze(sample_results + [ref_scoped])
+
+      file_nodes = analyzer.graph.vertices.select { |v| v.start_with?('file:') }
+
+      expect(file_nodes).not_to include('file:')
+      expect(analyzer.densely_connected_subgraph(1)[:nodes]).not_to include('finding:branch-never-merged:7')
+    end
+  end
 end

--- a/spec/html_report_spec.rb
+++ b/spec/html_report_spec.rb
@@ -118,5 +118,37 @@ RSpec.describe 'SarifReport' do
       expect(report.results.first.description).to match 'Suspicious use of netcat with IP address'
       expect(report.results.first.severity).to eq 'error'
     end
+
+    context 'with findings that are not file-scoped' do
+      # Named distinctly because the enclosing context assigns a plain local
+      # variable called 'report', which would lexically shadow a let of that name.
+      let(:topology_report) { HtmlReport.new('spec/fixtures/logical_location.sarif', nil).generate }
+
+      # This used to raise NoMethodError on the missing physicalLocation, which
+      # took down the whole report rather than the one result - every other
+      # tool's findings went with it.
+      it 'reads a result carrying only a logicalLocation' do
+        finding = topology_report.results.first
+
+        expect(finding.file_url).to be_nil
+        expect(finding.logical_location).to eq 'origin/release/1.8'
+        expect(finding.severity).to eq 'error'
+      end
+
+      it 'still reads file-scoped results in the same run' do
+        finding = topology_report.results.last
+
+        expect(finding.file_url).to eq 'src/main/java/Payment.java'
+        expect(finding.logical_location).to be_nil
+      end
+
+      it 'renders them without a dead file link' do
+        HtmlReport.new('spec/fixtures/logical_location.sarif', 'logical.html').generate.publish
+        html = File.read('logical.html')
+
+        expect(html).to match 'origin/release/1.8'
+        expect(html).not_to match 'href="file://.*release/1.8"'
+      end
+    end
   end
 end

--- a/spec/support/git_fixture.rb
+++ b/spec/support/git_fixture.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'open3'
+
+# Builds throwaway repositories with a known topology in a temp dir.
+#
+# The topology checks are entirely history-shaped, so there is no way to
+# exercise them without real commit graphs - stubbing git out would only test
+# the stub. Commit dates are settable because severity keys off branch age.
+class GitFixture
+  attr_reader :path
+
+  def initialize(path)
+    @path = path
+    @counter = 0
+    FileUtils.mkdir_p(path)
+    git('init', '-q', '-b', 'main')
+    git('config', 'user.email', 'fixture@example.com')
+    git('config', 'user.name', 'Fixture')
+    git('config', 'commit.gpgsign', 'false')
+  end
+
+  def git(*args, env: {})
+    out, err, status = Open3.capture3(env, 'git', '-C', @path, *args)
+    raise "git #{args.join(' ')} failed: #{err}" unless status.success?
+
+    out
+  end
+
+  def commit(message, files: nil, days_ago: 0)
+    files ||= { "file#{@counter += 1}.txt" => message }
+    files.each do |name, content|
+      full = File.join(@path, name)
+      FileUtils.mkdir_p(File.dirname(full))
+      File.write(full, content)
+    end
+    git('add', '-A')
+    git('commit', '-q', '-m', message, env: date_env(days_ago))
+    git('rev-parse', 'HEAD').strip
+  end
+
+  def create_branch(name)
+    git('checkout', '-q', '-b', name)
+  end
+
+  def checkout(name)
+    git('checkout', '-q', name)
+  end
+
+  # resolve: auto-resolves conflicts with -X ours. A merge whose two sides both
+  # rewrote the same files is exactly what the overlap check is looking for, and
+  # such a merge cannot be recorded at all without resolving it somehow. The
+  # strategy chosen does not affect which files each side touched.
+  def merge(name, days_ago: 0, message: nil, resolve: false)
+    args = ['merge', '--no-ff', '-q']
+    args += ['-X', 'ours'] if resolve
+    args += ['-m', message || "Merge #{name}", name]
+    git(*args, env: date_env(days_ago))
+  end
+
+  # What a forge's "Squash and merge" button leaves behind: one commit whose
+  # patch is the union of the branch's commits, and no ancestry link.
+  def squash_merge(name, days_ago: 0, message: nil)
+    git('merge', '--squash', '-q', name)
+    git('commit', '-q', '-m', message || "Squashed #{name}", env: date_env(days_ago))
+  end
+
+  # What "Rebase and merge" leaves behind: the branch's commits replayed onto
+  # the target, so per-commit patch IDs survive but ancestry does not.
+  def rebase_merge(name, days_ago: 0)
+    base = git('merge-base', 'HEAD', name).strip
+    git('rev-list', '--reverse', "#{base}..#{name}").split("\n").each do |rev|
+      git('cherry-pick', rev, env: date_env(days_ago))
+    end
+  end
+
+  def cherry_pick(rev, days_ago: 0)
+    git('cherry-pick', rev, env: date_env(days_ago))
+  end
+
+  # Mirror local heads into refs/remotes/origin/, which is what the analyser
+  # sees in a real clone.
+  def publish!
+    git('for-each-ref', '--format=%(refname:short) %(objectname)', 'refs/heads/')
+      .split("\n").each do |line|
+      name, sha = line.split
+      git('update-ref', "refs/remotes/origin/#{name}", sha)
+    end
+  end
+
+  def shallow_clone(dest)
+    _out, err, status = Open3.capture3('git', 'clone', '-q', '--depth', '1',
+                                       "file://#{@path}", dest)
+    raise "shallow clone failed: #{err}" unless status.success?
+
+    dest
+  end
+
+  private
+
+  def date_env(days_ago)
+    stamp = (Time.now - (days_ago * 86_400)).strftime('%Y-%m-%dT%H:%M:%S')
+    { 'GIT_AUTHOR_DATE' => stamp, 'GIT_COMMITTER_DATE' => stamp }
+  end
+end

--- a/spec/topology_analyzer_spec.rb
+++ b/spec/topology_analyzer_spec.rb
@@ -1,0 +1,351 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'fileutils'
+require_relative '../topology_analyzer'
+require_relative 'support/git_fixture'
+
+RSpec.describe TopologyAnalyzer do
+  around do |example|
+    Dir.mktmpdir('statica-topology') do |dir|
+      @tmp = dir
+      example.run
+    end
+  end
+
+  def repo_at(name = 'repo')
+    File.join(@tmp, name)
+  end
+
+  def findings_for(path)
+    described_class.new(path).run
+  end
+
+  def rule_ids(findings)
+    findings.map(&:rule_id)
+  end
+
+  # Every fixture starts from a mainline with enough shared files that a merge
+  # can plausibly overlap.
+  def base_repo(name = 'repo')
+    fixture = GitFixture.new(repo_at(name))
+    files = (1..12).to_h { |i| ["src/f#{i}.rb", "original #{i}\n"] }
+    fixture.commit('base', files: files, days_ago: 365)
+    fixture
+  end
+
+  def touch_all(prefix, count: 12)
+    (1..count).to_h { |i| ["src/f#{i}.rb", "#{prefix} #{i}\n"] }
+  end
+
+  describe 'degrading when there is no usable history' do
+    it 'produces nothing at all for a directory with no .git' do
+      plain = File.join(@tmp, 'plain')
+      FileUtils.mkdir_p(plain)
+      File.write(File.join(plain, 'app.rb'), 'puts 1')
+
+      analyzer = described_class.new(plain)
+
+      expect(analyzer.run).to be_empty
+      expect(analyzer.notes).to be_empty
+    end
+
+    it 'still emits a valid, empty SARIF document when there is no repository' do
+      plain = File.join(@tmp, 'plain')
+      FileUtils.mkdir_p(plain)
+      analyzer = described_class.new(plain)
+
+      parsed = JSON.parse(analyzer.sarif_json(analyzer.run))
+
+      expect(parsed['runs'][0]['results']).to eq([])
+      expect(parsed['runs'][0]['tool']['driver']['name']).to eq('topology')
+    end
+
+    it 'skips the checks on a shallow clone rather than guessing' do
+      fixture = base_repo
+      fixture.create_branch('feature/abandoned')
+      fixture.commit('abandoned work', days_ago: 200)
+      fixture.checkout('main')
+      fixture.commit('mainline moves on', days_ago: 100)
+      fixture.publish!
+
+      shallow = fixture.shallow_clone(File.join(@tmp, 'shallow'))
+      analyzer = described_class.new(shallow)
+
+      expect(analyzer.run).to be_empty
+      expect(analyzer.notes.join).to match(/shallow/)
+    end
+
+    it 'reports an empty repository as incomplete rather than crashing' do
+      empty = File.join(@tmp, 'empty')
+      GitFixture.new(empty)
+
+      expect(findings_for(empty)).to be_empty
+    end
+  end
+
+  describe 'branches that never merge down' do
+    it 'reports a genuinely abandoned branch' do
+      fixture = base_repo
+      fixture.create_branch('feature/abandoned')
+      fixture.commit('work nobody landed', days_ago: 200)
+      fixture.checkout('main')
+      fixture.commit('mainline moves on', days_ago: 100)
+      fixture.publish!
+
+      findings = findings_for(repo_at)
+      abandoned = findings.select { |f| f.rule_id == 'branch-never-merged' }
+
+      expect(abandoned.map(&:ref)).to eq(['origin/feature/abandoned'])
+      expect(abandoned.first.message).to match(/never been merged into main/)
+    end
+
+    it 'does not report a squash-merged branch' do
+      fixture = base_repo
+      fixture.create_branch('feature/squashed')
+      fixture.commit('part one', days_ago: 200)
+      fixture.commit('part two', days_ago: 200)
+      fixture.checkout('main')
+      fixture.squash_merge('feature/squashed', days_ago: 190)
+      fixture.publish!
+
+      expect(rule_ids(findings_for(repo_at))).not_to include('branch-never-merged')
+    end
+
+    it 'does not report a rebase-merged branch' do
+      fixture = base_repo
+      fixture.create_branch('feature/rebased')
+      fixture.commit('part one', days_ago: 200)
+      fixture.commit('part two', days_ago: 200)
+      fixture.checkout('main')
+      fixture.commit('mainline moves first', days_ago: 195)
+      fixture.rebase_merge('feature/rebased', days_ago: 190)
+      fixture.publish!
+
+      expect(rule_ids(findings_for(repo_at))).not_to include('branch-never-merged')
+    end
+
+    it 'does not report a branch that is too young to have landed yet' do
+      fixture = base_repo
+      fixture.create_branch('feature/in-progress')
+      fixture.commit('still working', days_ago: 3)
+      fixture.checkout('main')
+      fixture.publish!
+
+      expect(rule_ids(findings_for(repo_at))).not_to include('branch-never-merged')
+    end
+
+    it 'does not report branches that are conventional dead ends' do
+      fixture = base_repo
+      %w[spike/idea archive/old wip/scratch].each do |name|
+        fixture.checkout('main')
+        fixture.create_branch(name)
+        fixture.commit("work on #{name}", days_ago: 300)
+      end
+      fixture.checkout('main')
+      fixture.publish!
+
+      expect(rule_ids(findings_for(repo_at))).not_to include('branch-never-merged')
+    end
+
+    it 'escalates severity with how long the branch has been sitting' do
+      fixture = base_repo
+      fixture.create_branch('feature/ancient')
+      fixture.commit('long forgotten', days_ago: 300)
+      fixture.checkout('main')
+      fixture.create_branch('feature/recent')
+      fixture.commit('recently stalled', days_ago: 45)
+      fixture.checkout('main')
+      fixture.publish!
+
+      levels = findings_for(repo_at)
+               .select { |f| f.rule_id == 'branch-never-merged' }
+               .to_h { |f| [f.ref, f.level] }
+
+      expect(levels['origin/feature/ancient']).to eq('error')
+      expect(levels['origin/feature/recent']).to eq('note')
+    end
+
+    it 'does not treat the origin/HEAD symref as a branch' do
+      fixture = base_repo
+      fixture.commit('mainline work', days_ago: 200)
+      fixture.publish!
+      # refs/remotes/origin/HEAD shortens to "origin", so filtering on the short
+      # name alone lets it through as a phantom branch.
+      fixture.git('symbolic-ref', 'refs/remotes/origin/HEAD', 'refs/remotes/origin/main')
+
+      metrics = findings_for(repo_at).find { |f| f.rule_id == 'topology-metrics' }
+
+      expect(metrics.message).to match(/\b1 branches currently exist/)
+    end
+
+    it 'counts commits ahead of a branch it is actually missing from' do
+      fixture = base_repo
+      fixture.create_branch('develop')
+      fixture.checkout('main')
+      fixture.commit('mainline moves ahead', days_ago: 100)
+      fixture.create_branch('feature/landed-on-main')
+      fixture.commit('feature work', days_ago: 90)
+      fixture.checkout('main')
+      fixture.merge('feature/landed-on-main', days_ago: 89)
+      fixture.publish!
+
+      finding = findings_for(repo_at)
+                .find { |f| f.rule_id == 'branch-never-merged' && f.ref.include?('landed-on-main') }
+
+      expect(finding.message).to match(/never been merged into develop/)
+      expect(finding.message).to match(/2 commits ahead of develop/)
+    end
+
+    it 'falls back to local branches when the repository has no remote refs' do
+      fixture = base_repo
+      fixture.create_branch('feature/abandoned')
+      fixture.commit('work nobody landed', days_ago: 200)
+      fixture.checkout('main')
+
+      refs = findings_for(repo_at)
+             .select { |f| f.rule_id == 'branch-never-merged' }
+             .map(&:ref)
+
+      expect(refs).to eq(['feature/abandoned'])
+    end
+  end
+
+  describe 'commits stranded on a release line' do
+    it 'reports a fix that never made it back to mainline' do
+      fixture = base_repo
+      fixture.create_branch('release/1.8')
+      fixture.commit('urgent fix on the release line', days_ago: 60)
+      fixture.checkout('main')
+      fixture.commit('unrelated mainline work', days_ago: 50)
+      fixture.publish!
+
+      stranded = findings_for(repo_at).select { |f| f.rule_id == 'release-commit-not-forward-ported' }
+
+      expect(stranded.map(&:ref)).to eq(['origin/release/1.8'])
+      expect(stranded.first.message).to match(/urgent fix on the release line/)
+    end
+
+    it 'does not report a commit that was cherry-picked to mainline' do
+      fixture = base_repo
+      fixture.create_branch('release/1.9')
+      sha = fixture.commit('fix that was forward-ported', days_ago: 60)
+      fixture.checkout('main')
+      fixture.cherry_pick(sha, days_ago: 55)
+      fixture.publish!
+
+      expect(rule_ids(findings_for(repo_at))).not_to include('release-commit-not-forward-ported')
+    end
+  end
+
+  describe 'expensive merges' do
+    it 'reports a long-lived branch with heavy file overlap' do
+      fixture = base_repo
+      fixture.create_branch('feature/long-lived')
+      6.times do |i|
+        fixture.commit("feature change #{i}", files: touch_all("feature #{i}"), days_ago: 100 - i)
+      end
+      fixture.checkout('main')
+      6.times do |i|
+        fixture.commit("mainline change #{i}", files: touch_all("mainline #{i}"), days_ago: 100 - i)
+      end
+      fixture.merge('feature/long-lived', days_ago: 20, resolve: true)
+      fixture.publish!
+
+      findings = findings_for(repo_at)
+
+      expect(rule_ids(findings)).to include('merge-high-divergence', 'merge-high-overlap')
+    end
+
+    it 'carries the overlapping file paths so they reach the hotspot analysis' do
+      fixture = base_repo
+      fixture.create_branch('feature/long-lived')
+      6.times do |i|
+        fixture.commit("feature change #{i}", files: touch_all("feature #{i}"), days_ago: 100 - i)
+      end
+      fixture.checkout('main')
+      6.times do |i|
+        fixture.commit("mainline change #{i}", files: touch_all("mainline #{i}"), days_ago: 100 - i)
+      end
+      fixture.merge('feature/long-lived', days_ago: 20, resolve: true)
+      fixture.publish!
+
+      overlap = findings_for(repo_at).find { |f| f.rule_id == 'merge-high-overlap' }
+
+      expect(overlap.files).to include('src/f1.rb')
+      expect(overlap.files.length).to be <= described_class::OVERLAP_MAX_LOCATIONS
+    end
+
+    it 'produces nothing for a clean, short-lived branch merge' do
+      fixture = base_repo
+      fixture.commit('mainline settles', days_ago: 30)
+      fixture.create_branch('feature/tidy')
+      fixture.commit('one small change', files: { 'src/f1.rb' => "tidy\n" }, days_ago: 5)
+      fixture.checkout('main')
+      fixture.merge('feature/tidy', days_ago: 4)
+      fixture.publish!
+
+      substantive = findings_for(repo_at).reject { |f| f.rule_id == 'topology-metrics' }
+
+      expect(substantive).to be_empty
+    end
+  end
+
+  describe 'SARIF mapping' do
+    it 'gives ref-scoped findings a logicalLocation and no invented file' do
+      fixture = base_repo
+      fixture.create_branch('feature/abandoned')
+      fixture.commit('work nobody landed', days_ago: 200)
+      fixture.checkout('main')
+      fixture.publish!
+
+      analyzer = described_class.new(repo_at)
+      parsed = JSON.parse(analyzer.sarif_json(analyzer.run))
+      result = parsed['runs'][0]['results'].find { |r| r['ruleId'] == 'branch-never-merged' }
+
+      expect(result['locations'][0]).not_to have_key('physicalLocation')
+      expect(result['locations'][0]['logicalLocations'][0]['name']).to eq('origin/feature/abandoned')
+    end
+
+    it 'sets a stable partial fingerprint that survives a re-run' do
+      fixture = base_repo
+      fixture.create_branch('feature/abandoned')
+      fixture.commit('work nobody landed', days_ago: 200)
+      fixture.checkout('main')
+      fixture.publish!
+
+      first = described_class.new(repo_at).run.map(&:fingerprint)
+      # A new commit on mainline must not re-open triage on the stale branch.
+      fixture.commit('unrelated mainline work', days_ago: 1)
+      fixture.publish!
+      second = described_class.new(repo_at).run.map(&:fingerprint)
+
+      expect(second).to include(*first.reject { |f| f == 'topology-metrics' })
+    end
+
+    it 'declares every emitted rule with a help URI and an explanation' do
+      analyzer = described_class.new(repo_at('none'))
+      rules = JSON.parse(analyzer.sarif_json([]))['runs'][0]['tool']['driver']['rules']
+
+      expect(rules.map { |r| r['id'] }).to match_array(described_class::RULES.keys)
+      expect(rules).to all(include('helpUri'))
+      expect(rules.map { |r| r['fullDescription']['text'] }).to all(be_a(String))
+    end
+  end
+
+  describe 'bounded runtime' do
+    it 'stops walking once the deadline has passed' do
+      fixture = base_repo
+      fixture.create_branch('feature/abandoned')
+      fixture.commit('work nobody landed', days_ago: 200)
+      fixture.checkout('main')
+      fixture.publish!
+
+      analyzer = described_class.new(repo_at, deadline_seconds: -1)
+
+      expect(analyzer.run).to be_empty
+      expect(analyzer.notes.join).to match(/deadline/)
+    end
+  end
+end

--- a/statica.gemspec
+++ b/statica.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
     'csv2sarif',
     'graph_analyzer.rb',
     'html_report.rb',
+    'topology_analyzer.rb',
     'template.erb',
     'tools.d/*'
   ]

--- a/template.erb
+++ b/template.erb
@@ -87,6 +87,12 @@
           margin: 20px 0;
       }
 
+      /* Findings scoped to a ref rather than a file have nothing to link to */
+      .logical-location {
+          font-family: monospace;
+          color: #555;
+      }
+
       .hotspot-files table {
           width: 100%;
           border-collapse: collapse;
@@ -230,7 +236,12 @@
                       tool: f.tool,
                       locations: []
                   };
-                  group.locations.push(f.linenum > 0 ? (f.file_url + ':' + f.linenum) : f.file_url);
+                  if (!f.file_url) {
+                      // Ref-scoped finding: no file to cite, so name the branch instead
+                      group.locations.push(f.logical_location || 'repository');
+                  } else {
+                      group.locations.push(f.linenum > 0 ? (f.file_url + ':' + f.linenum) : f.file_url);
+                  }
                   bySeverity[f.severity][f.rule_id] = group;
               });
 
@@ -350,7 +361,11 @@
       <ul>
         <% results_matching.each do |finding| %>
           <li>
-            <a href="<%= get_url(finding.file_url, finding.linenum) %>" target="_blank"><%= finding.file_url %></a><%= finding.linenum > 0 ? ":#{finding.linenum}" : nil %>
+            <% if finding.file_url %>
+              <a href="<%= get_url(finding.file_url, finding.linenum) %>" target="_blank"><%= finding.file_url %></a><%= finding.linenum > 0 ? ":#{finding.linenum}" : nil %>
+            <% else %>
+              <span class="logical-location"><%= finding.logical_location || 'repository' %></span>
+            <% end %>
           </li>
         <% end %>
       </ul>

--- a/tools.d/topology
+++ b/tools.d/topology
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../topology_analyzer'
+
+source = ARGV[0]
+
+unless source
+  warn 'Usage: topology <path to app source>'
+  exit 1
+end
+
+analyzer = TopologyAnalyzer.new(source)
+findings = analyzer.run
+analyzer.notes.each { |note| warn "topology: #{note}" }
+
+# Always emit a valid SARIF document, even when there is nothing to say. Source
+# that arrived without a repository is the normal case for Statica, not a
+# failure, and exiting non-zero here would report it as one.
+puts analyzer.sarif_json(findings)

--- a/topology_analyzer.rb
+++ b/topology_analyzer.rb
@@ -1,0 +1,747 @@
+# frozen_string_literal: true
+
+require 'open3'
+require 'sarif'
+require 'set'
+
+# Reports on the health of a repository's branching workflow: branches that
+# never merge back, changes stranded on a release line, and merges that were
+# expensive because the branches were allowed to drift.
+#
+# Strictly read-only. Everything is computed from for-each-ref, rev-list,
+# merge-base, diff and patch-id; nothing here checks out, merges, fetches, or
+# touches the index, so it is safe against a bare or dirty repository that
+# someone else is working in.
+class TopologyAnalyzer
+  TOOL_NAME = 'topology'
+  # Anchors into the README's rule reference, one heading per rule id.
+  HELP_BASE = 'https://github.com/simpsonjulian/statica#'
+
+  # Bounded runtime. Every check fans out over refs or merges, and Statica gets
+  # pointed at large repositories, so each walk is capped and the whole run is
+  # abandoned once the deadline passes.
+  WINDOW_MONTHS = 12
+  MAX_MERGES = 1000
+  MAX_PATCH_ID_COMMITS = 2000
+  MAX_BRANCHES = 500
+  DEADLINE_SECONDS = 120
+
+  INTEGRATION_CANDIDATES = %w[main master develop].freeze
+  RELEASE_PATTERNS = [%r{\Arelease/}, %r{\Ahotfix/}].freeze
+
+  # Branches that are conventionally dead ends. Reporting them as unmerged is
+  # noise: not coming back is the whole point of a spike. The bot prefixes are
+  # here because a lingering dependabot branch means a superseded or closed
+  # pull request, which says nothing about the branching model - and on a repo
+  # with dependabot enabled they otherwise drown out the real findings.
+  EXCLUDED_PATTERNS = [
+    %r{\Aspikes?/}, %r{\Aarchived?/}, %r{\Aexperiments?/},
+    %r{\Atmp/}, %r{\Awip/}, %r{\Apocs?/},
+    %r{\Adependabot/}, %r{\Arenovate/}
+  ].freeze
+
+  # A branch is only worth mentioning once it has been abandoned for a while.
+  # A feature branch a few days old is just work in progress, so severity keys
+  # off how long it has been sitting rather than the mere fact of existing.
+  STALE_AFTER_DAYS = 30
+  BRANCH_LEVELS = [[180, 'error'], [90, 'warning'], [STALE_AFTER_DAYS, 'note']].freeze
+
+  # Divergence needs both sides to have genuinely moved, otherwise it fires on
+  # a branch that simply sat still while mainline advanced - which is check 1's
+  # problem, not this one's.
+  DIVERGENCE_DAYS = 56
+  DIVERGENCE_DAYS_HIGH = 112
+  DIVERGENCE_MIN_COMMITS = 5
+
+  OVERLAP_MIN_FILES = 10
+  OVERLAP_MIN_RATIO = 0.25
+  OVERLAP_HIGH_FILES = 30
+  # Overlap findings carry real paths so they reach the hotspot table, but a
+  # merge touching 400 shared files should not emit 400 results.
+  OVERLAP_MAX_LOCATIONS = 10
+
+  BIG_MERGE_FILES = 100
+  BIG_MERGE_LINES = 10_000
+
+  BACK_MERGE_THRESHOLD = 3
+
+  RULES = {
+    'branch-never-merged' => {
+      level: 'warning',
+      text: 'Branch has never been merged into an integration branch',
+      help: 'A branch that stopped moving but never landed is either abandoned work nobody ' \
+            'deleted, or a change someone believes shipped and did not. Both are worth ' \
+            'resolving: delete it, or merge it. Squash- and rebase-merged branches are ' \
+            'detected by patch ID and are not reported.'
+    },
+    'release-commit-not-forward-ported' => {
+      level: 'warning',
+      text: 'Commits exist on a release branch but not on mainline',
+      help: 'A fix applied to a release line and never forward-ported disappears at the next ' \
+            'release, and typically resurfaces as a reopened bug. Commits that were ' \
+            'cherry-picked to mainline are detected by patch ID and are not reported.'
+    },
+    'merge-high-divergence' => {
+      level: 'warning',
+      text: 'Branches developed in parallel for a long time before merging',
+      help: 'The merge is where the pain surfaced, but the cause is how long the two sides ' \
+            'were allowed to drift. Long-lived parallel development makes every merge more ' \
+            'expensive and every conflict resolution more likely to be wrong.'
+    },
+    'merge-high-overlap' => {
+      level: 'warning',
+      text: 'Merge had to reconcile many files changed on both sides',
+      help: 'Files modified on both sides of the merge base are the files the merge had to ' \
+            'reconcile by hand. Sustained high overlap means two streams of work are ' \
+            'competing for the same code and the branching model is not keeping them apart.'
+    },
+    'merge-large' => {
+      level: 'note',
+      text: 'Merge integrated a large amount of change at once',
+      help: 'Big-bang integrations are hard to review and hard to bisect. The size itself is ' \
+            'not a defect, but it bounds how much confidence any review of it could have had.'
+    },
+    'repeated-back-merge' => {
+      level: 'note',
+      text: 'Mainline was merged into this branch repeatedly before it landed',
+      help: 'Repeatedly pulling mainline into a branch is how a long-lived branch stays ' \
+            'merge-able. It is a reliable symptom of a branch that lived longer than the ' \
+            'work justified.'
+    },
+    'criss-cross-merge' => {
+      level: 'note',
+      text: 'Branches have merged into each other in both directions',
+      help: 'Two branches merged into each other produce multiple merge bases, which makes ' \
+            'later merges ambiguous and history hard to reason about. Git has to pick a base, ' \
+            'and the one it picks may not be the one you would.'
+    },
+    'topology-metrics' => {
+      level: 'note',
+      text: 'Branching topology metrics',
+      help: 'Context for a human reading the rest of the report. These are descriptive ' \
+            'measurements of the commit graph, not defects, and are deliberately not ' \
+            'combined into a score.'
+    }
+  }.freeze
+
+  # Checked against the deadline between each one, as well as inside their own
+  # walks, so an expired run stops paying for the checks it has not started.
+  CHECKS = %i[
+    unmerged_branches stranded_release_commits merge_findings criss_cross_merges metrics
+  ].freeze
+
+  Branch = Struct.new(:ref, :name, :sha, :committed_at, keyword_init: true)
+  Finding = Struct.new(:rule_id, :level, :message, :ref, :files, :fingerprint, keyword_init: true)
+
+  # Read-only git access. GIT_OPTIONAL_LOCKS=0 stops git taking the index lock
+  # for the refresh some commands would otherwise do.
+  class Repo
+    ENV_OVERRIDES = { 'GIT_OPTIONAL_LOCKS' => '0' }.freeze
+
+    def initialize(path)
+      @path = path
+    end
+
+    def capture(*args)
+      out, _err, status = Open3.capture3(ENV_OVERRIDES, 'git', '-C', @path, '--no-pager', *args)
+      [out, status.success?]
+    end
+
+    def lines(*args)
+      out, ok = capture(*args)
+      return [] unless ok
+
+      out.split("\n").reject(&:empty?)
+    end
+
+    def value(*args)
+      out, ok = capture(*args)
+      return nil unless ok
+
+      stripped = out.strip
+      stripped.empty? ? nil : stripped
+    end
+
+    def ok?(*args)
+      _out, ok = capture(*args)
+      ok
+    end
+
+    # patch-id reads a diff on stdin, so these are the only places a pipeline is
+    # needed. Piping a whole `log -p` through one patch-id call maps every
+    # commit in a range in a single pass; doing it per commit is unusably slow
+    # on a real repository.
+    def patch_ids(*git_args)
+      result = {}
+      Open3.pipeline_r(
+        [ENV_OVERRIDES, 'git', '-C', @path, '--no-pager', *git_args],
+        ['git', 'patch-id', '--stable']
+      ) do |stdout, _waiters|
+        stdout.each_line do |line|
+          patch, commit = line.split
+          result[patch] = commit if patch && commit
+        end
+      end
+      result
+    end
+  end
+
+  attr_reader :notes
+
+  def initialize(source, deadline_seconds: DEADLINE_SECONDS)
+    @source = source
+    @repo = Repo.new(source)
+    @deadline = monotonic + deadline_seconds
+    @notes = []
+    @patch_id_cache = {}
+  end
+
+  # Returns the findings, or [] when there is nothing meaningful to say. The
+  # two silent cases are deliberate: a source tree with no repository at all
+  # (Statica's bread and butter is a zip someone emailed over) and a clone whose
+  # history is too incomplete to reason about.
+  def run
+    return [] unless repository?
+
+    reason = incomplete_history_reason
+    if reason
+      @notes << "#{reason}, topology checks skipped"
+      return []
+    end
+
+    findings = []
+    CHECKS.each do |check|
+      break if expired?
+
+      findings.concat(send(check))
+    end
+    @notes << 'deadline reached, results are partial' if expired?
+    findings
+  end
+
+  def repository?
+    @repo.ok?('rev-parse', '--git-dir')
+  end
+
+  # A shallow or partial clone makes almost every check here produce confident
+  # garbage: the merge base is simply absent, so every branch looks unmerged.
+  # Refusing is the only honest option.
+  def incomplete_history_reason
+    return 'history is shallow' if @repo.value('rev-parse', '--is-shallow-repository') == 'true'
+    return 'clone is partial' if partial_clone?
+    return 'repository has no commits' if @repo.value('rev-parse', '--verify', '--quiet', 'HEAD').nil?
+
+    nil
+  end
+
+  # The sarif gem omits an empty results array entirely, which produces the
+  # `"results":null` shape that statica already has to special-case for bearer
+  # before handing files to `sarif summary`. Emitting an explicit [] keeps a
+  # findings-free run from becoming a second instance of that bug.
+  def sarif_json(findings)
+    document = JSON.parse(to_sarif(findings).to_json)
+    document['runs'].each { |run| run['results'] ||= [] }
+    JSON.generate(document)
+  end
+
+  def to_sarif(findings)
+    Sarif::Log.new(
+      version: '2.1.0',
+      runs: [
+        Sarif::Run.new(
+          tool: Sarif::Tool.new(driver: Sarif::ToolComponent.new(
+            name: TOOL_NAME,
+            version: git_version,
+            information_uri: 'https://github.com/simpsonjulian/statica',
+            organization: 'simpsonjulian',
+            rules: RULES.map do |id, rule|
+              Sarif::ReportingDescriptor.new(
+                id: id,
+                short_description: Sarif::MultiformatMessageString.new(text: rule[:text]),
+                full_description: Sarif::MultiformatMessageString.new(text: rule[:help]),
+                help_uri: "#{HELP_BASE}#{id}"
+              )
+            end
+          )),
+          results: findings.map { |finding| to_result(finding) }
+        )
+      ]
+    )
+  end
+
+  private
+
+  def monotonic
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+
+  def expired?
+    monotonic > @deadline
+  end
+
+  def since_arg
+    "--since=#{WINDOW_MONTHS}.months.ago"
+  end
+
+  def git_version
+    @git_version ||= @repo.value('--version')&.sub(/\Agit version /, '') || 'unknown'
+  end
+
+  def partial_clone?
+    !@repo.lines('config', '--get-regexp', '^remote\..*\.(promisor|partialclonefilter)$').empty?
+  end
+
+  def to_result(finding)
+    locations =
+      if finding.files && !finding.files.empty?
+        finding.files.map do |file|
+          Sarif::Location.new(physical_location: Sarif::PhysicalLocation.new(
+            artifact_location: Sarif::ArtifactLocation.new(uri: file)
+          ))
+        end
+      else
+        # Nothing to point at in the tree. A synthetic physicalLocation would
+        # invent a file that does not exist and drag it into the hotspot table,
+        # so these carry a logicalLocation naming the ref instead.
+        [Sarif::Location.new(logical_locations: [
+                               Sarif::LogicalLocation.new(name: finding.ref, fully_qualified_name: finding.ref)
+                             ])]
+      end
+
+    Sarif::Result.new(
+      rule_id: finding.rule_id,
+      level: finding.level,
+      message: Sarif::Message.new(text: finding.message),
+      locations: locations,
+      partial_fingerprints: { 'topology/v1' => finding.fingerprint }
+    )
+  end
+
+  # --- refs -----------------------------------------------------------------
+
+  def all_branches
+    @all_branches ||= begin
+      remote = refs_under('refs/remotes/')
+      # A repository with no remotes is normal for source that arrived as an
+      # archive; fall back to local branches rather than reporting nothing.
+      remote.empty? ? refs_under('refs/heads/') : remote
+    end
+  end
+
+  def refs_under(prefix)
+    remote_scoped = prefix.start_with?('refs/remotes')
+    @repo.lines('for-each-ref',
+                '--format=%(refname)%09%(refname:short)%09%(objectname)%09%(committerdate:unix)',
+                prefix).filter_map do |line|
+      full, short, sha, timestamp = line.split("\t")
+      # refs/remotes/origin/HEAD shortens to just "origin", so the symref has to
+      # be filtered on its full name or it turns into a phantom branch.
+      next if short.nil? || short.empty? || full.to_s.end_with?('/HEAD')
+
+      name = remote_scoped ? short.split('/', 2).last : short
+      Branch.new(ref: short, name: name, sha: sha, committed_at: Time.at(timestamp.to_i))
+    end.first(MAX_BRANCHES)
+  end
+
+  def integration_branches
+    @integration_branches ||= all_branches.select { |b| INTEGRATION_CANDIDATES.include?(b.name) }
+  end
+
+  def mainline
+    @mainline ||= INTEGRATION_CANDIDATES.filter_map do |name|
+      integration_branches.find { |b| b.name == name }
+    end.first
+  end
+
+  def release_branches
+    all_branches.select { |b| release_line?(b.name) }
+  end
+
+  def release_line?(name)
+    RELEASE_PATTERNS.any? { |pattern| name.match?(pattern) }
+  end
+
+  def excluded?(name)
+    EXCLUDED_PATTERNS.any? { |pattern| name.match?(pattern) }
+  end
+
+  def days_between(later, earlier)
+    ((later - earlier) / 86_400.0).floor
+  end
+
+  def commit_time(rev)
+    timestamp = @repo.value('log', '-1', '--format=%ct', rev)
+    timestamp && Time.at(timestamp.to_i)
+  end
+
+  def parents_of(sha)
+    @repo.value('rev-list', '--parents', '-n', '1', sha).to_s.split[1..] || []
+  end
+
+  def count_commits(range)
+    @repo.value('rev-list', '--count', range).to_i
+  end
+
+  # --- check 1: branches that never merge down ------------------------------
+
+  def unmerged_branches
+    return [] if integration_branches.empty?
+
+    findings = []
+    candidates = all_branches.reject { |b| INTEGRATION_CANDIDATES.include?(b.name) || excluded?(b.name) }
+
+    candidates.each do |branch|
+      break if expired?
+
+      days = days_between(Time.now, branch.committed_at)
+      level = branch_level(days)
+      next if level.nil?
+
+      missing = targets_for(branch).reject { |target| merged_into?(branch, target) }
+      next if missing.empty?
+
+      findings << unmerged_finding(branch, missing, days)
+      findings.concat(back_merge_finding(branch))
+    end
+
+    findings
+  end
+
+  # Mainline is deliberately not a target for release lines: check 2 owns that
+  # relationship and describes it far better, naming the actual commits rather
+  # than just saying the branch never landed.
+  def targets_for(branch)
+    return integration_branches unless release_line?(branch.name)
+
+    integration_branches.reject { |target| target.ref == mainline&.ref }
+  end
+
+  def branch_level(days)
+    BRANCH_LEVELS.each { |threshold, level| return level if days >= threshold }
+    nil
+  end
+
+  def unmerged_finding(branch, missing, days)
+    # Counted against a branch it is actually missing from. Measuring against
+    # mainline instead reports "0 commits ahead" for a branch that landed on
+    # main but never reached develop, which reads as a contradiction.
+    reference = missing.first
+    ahead = count_commits("#{reference.ref}..#{branch.ref}")
+    targets = missing.map(&:name).join(', ')
+    Finding.new(
+      rule_id: 'branch-never-merged',
+      level: branch_level(days),
+      message: "Branch '#{branch.name}' was last committed to #{days} days ago and has never " \
+               "been merged into #{targets}. It is #{ahead} commit#{'s' unless ahead == 1} " \
+               "ahead of #{reference.name}. Ancestry, patch ID and squash detection all agree " \
+               'it never landed.',
+      ref: branch.ref,
+      fingerprint: "branch-never-merged:#{branch.name}"
+    )
+  end
+
+  # Ancestry alone reports every squash-merged branch as unmerged, and squash
+  # merges are the default on most forges, so this layers three tests. git
+  # cherry catches rebase and cherry-pick, where per-commit patch IDs survive.
+  # It does *not* catch a squashed multi-commit branch, because the squash
+  # collapses N commits into one whose patch ID matches none of them - that
+  # needs the branch's cumulative diff compared against mainline's commits.
+  def merged_into?(branch, target)
+    return true if @repo.ok?('merge-base', '--is-ancestor', branch.sha, target.ref)
+    return true if cherry_all_upstream?(branch, target)
+
+    squashed_into?(branch, target)
+  end
+
+  def cherry_all_upstream?(branch, target)
+    out, ok = @repo.capture('cherry', target.ref, branch.ref)
+    return false unless ok
+
+    lines = out.split("\n").reject(&:empty?)
+    return false if lines.empty?
+
+    lines.none? { |line| line.start_with?('+') }
+  end
+
+  def squashed_into?(branch, target)
+    base = @repo.value('merge-base', target.ref, branch.ref)
+    return false if base.nil?
+
+    cumulative = @repo.patch_ids('diff', base, branch.ref).keys.first
+    return false if cumulative.nil?
+
+    patch_ids_for(target).key?(cumulative)
+  end
+
+  def patch_ids_for(target)
+    @patch_id_cache[target.ref] ||= @repo.patch_ids(
+      'log', '-p', '--no-merges', "--max-count=#{MAX_PATCH_ID_COMMITS}", since_arg, target.ref
+    )
+  end
+
+  # Only computed for branches already known to be unmerged, which keeps an
+  # otherwise quadratic walk nearly free.
+  def back_merge_finding(branch)
+    main = mainline
+    return [] if main.nil?
+
+    base = @repo.value('merge-base', main.ref, branch.ref)
+    return [] if base.nil?
+
+    count = @repo.lines('rev-list', '--merges', "--max-count=#{MAX_MERGES}",
+                        "#{base}..#{branch.ref}").count do |merge|
+      parents = parents_of(merge)
+      parents.length == 2 && @repo.ok?('merge-base', '--is-ancestor', parents[1], main.ref)
+    end
+    return [] if count < BACK_MERGE_THRESHOLD
+
+    [Finding.new(
+      rule_id: 'repeated-back-merge',
+      level: 'note',
+      message: "Branch '#{branch.name}' merged #{main.name} into itself #{count} times without " \
+               'ever merging back. Keeping a branch merge-able for that long usually means it ' \
+               'should have been split.',
+      ref: branch.ref,
+      fingerprint: "repeated-back-merge:#{branch.name}"
+    )]
+  end
+
+  # --- check 2: commits stranded on a release line --------------------------
+
+  def stranded_release_commits
+    main = mainline
+    return [] if main.nil?
+
+    findings = []
+    release_branches.each do |branch|
+      break if expired?
+
+      # --cherry-pick is load-bearing: without it every commit that was
+      # cherry-picked to mainline rather than merged is reported as missing,
+      # which on a real release line is most of them.
+      shas = @repo.lines('rev-list', '--right-only', '--cherry-pick', '--no-merges',
+                         "--max-count=#{MAX_MERGES}", since_arg,
+                         "#{main.ref}...#{branch.ref}")
+      next if shas.empty?
+
+      findings << stranded_finding(branch, main, shas)
+    end
+    findings
+  end
+
+  def stranded_finding(branch, main, shas)
+    subjects = shas.first(5).filter_map { |sha| @repo.value('log', '-1', '--format=%h %s', sha) }
+    more = shas.length > subjects.length ? " (and #{shas.length - subjects.length} more)" : ''
+    Finding.new(
+      rule_id: 'release-commit-not-forward-ported',
+      level: shas.length > 10 ? 'error' : 'warning',
+      message: "#{shas.length} commit#{'s' unless shas.length == 1} on '#{branch.name}' " \
+               "#{shas.length == 1 ? 'is' : 'are'} not on #{main.name} and #{shas.length == 1 ? 'was' : 'were'} " \
+               "not cherry-picked there: #{subjects.join('; ')}#{more}. These changes will be " \
+               'absent from the next release cut from mainline.',
+      ref: branch.ref,
+      fingerprint: "release-commit-not-forward-ported:#{branch.name}"
+    )
+  end
+
+  # --- check 3: expensive merges --------------------------------------------
+
+  def merge_findings
+    return [] if integration_branches.empty?
+
+    refs = integration_branches.map(&:ref)
+    findings = []
+    @repo.lines('rev-list', '--merges', "--max-count=#{MAX_MERGES}", since_arg, *refs).each do |sha|
+      break if expired?
+
+      findings.concat(analyse_merge(sha))
+    end
+    findings
+  end
+
+  def analyse_merge(sha)
+    parents = parents_of(sha)
+    # Octopus merges have no single "other side" to measure divergence against.
+    return [] unless parents.length == 2
+
+    base = @repo.value('merge-base', parents[0], parents[1])
+    return [] if base.nil?
+
+    left = count_commits("#{base}..#{parents[0]}")
+    right = count_commits("#{base}..#{parents[1]}")
+    left_files = Set.new(@repo.lines('diff', '--name-only', base, parents[0]))
+    right_files = Set.new(@repo.lines('diff', '--name-only', base, parents[1]))
+    overlap = (left_files & right_files).to_a.sort
+
+    findings = []
+    findings.concat(divergence_finding(sha, base, left, right))
+    findings.concat(overlap_finding(sha, left_files, right_files, overlap))
+    findings.concat(size_finding(sha, parents[0]))
+    findings
+  end
+
+  def divergence_finding(sha, base, left, right)
+    merged_at = commit_time(sha)
+    based_at = commit_time(base)
+    return [] if merged_at.nil? || based_at.nil?
+
+    days = days_between(merged_at, based_at)
+    return [] if days < DIVERGENCE_DAYS
+    return [] if [left, right].min < DIVERGENCE_MIN_COMMITS
+
+    [Finding.new(
+      rule_id: 'merge-high-divergence',
+      level: days >= DIVERGENCE_DAYS_HIGH ? 'error' : 'warning',
+      message: "Merge #{short(sha)} joined two sides that had diverged for #{days} days, with " \
+               "#{left} and #{right} commits developed in parallel. The merge is where this " \
+               'surfaced; the cost was incurred over the preceding weeks.',
+      ref: short(sha),
+      fingerprint: "merge-high-divergence:#{sha}"
+    )]
+  end
+
+  def overlap_finding(sha, left_files, right_files, overlap)
+    smaller = [left_files.size, right_files.size].min
+    return [] if smaller.zero? || overlap.size < OVERLAP_MIN_FILES
+
+    ratio = overlap.size.to_f / smaller
+    return [] if ratio < OVERLAP_MIN_RATIO
+
+    capped = overlap.first(OVERLAP_MAX_LOCATIONS)
+    truncated = overlap.size > capped.size ? " Showing #{capped.size} of #{overlap.size}." : ''
+    [Finding.new(
+      rule_id: 'merge-high-overlap',
+      level: overlap.size >= OVERLAP_HIGH_FILES ? 'error' : 'warning',
+      message: "Merge #{short(sha)} had to reconcile #{overlap.size} files changed on both " \
+               "sides (#{(ratio * 100).round}% of the smaller side).#{truncated}",
+      ref: short(sha),
+      files: capped,
+      fingerprint: "merge-high-overlap:#{sha}"
+    )]
+  end
+
+  def size_finding(sha, first_parent)
+    rows = @repo.lines('diff', '--numstat', first_parent, sha)
+    return [] if rows.empty?
+
+    changed = rows.sum do |row|
+      added, deleted, = row.split("\t")
+      added.to_i + deleted.to_i
+    end
+    return [] if rows.length < BIG_MERGE_FILES && changed < BIG_MERGE_LINES
+
+    [Finding.new(
+      rule_id: 'merge-large',
+      level: 'note',
+      message: "Merge #{short(sha)} integrated #{rows.length} files and #{changed} changed " \
+               'lines in one step.',
+      ref: short(sha),
+      fingerprint: "merge-large:#{sha}"
+    )]
+  end
+
+  def short(sha)
+    sha[0, 12]
+  end
+
+  # --- criss-cross ----------------------------------------------------------
+
+  # Two branches merged into each other leave more than one merge base, which
+  # is both the symptom and the reason it matters. One command per pair, and
+  # only over integration branches, so the pairwise walk stays small.
+  def criss_cross_merges
+    pairs = integration_branches.combination(2).to_a
+    findings = []
+    pairs.each do |left, right|
+      break if expired?
+
+      bases = @repo.lines('merge-base', '--all', left.ref, right.ref)
+      next if bases.length < 2
+
+      findings << Finding.new(
+        rule_id: 'criss-cross-merge',
+        level: 'note',
+        message: "'#{left.name}' and '#{right.name}' have #{bases.length} merge bases, meaning " \
+                 'they have been merged into each other in both directions. Future merges ' \
+                 'between them will pick one base ambiguously.',
+        ref: "#{left.name}...#{right.name}",
+        fingerprint: "criss-cross-merge:#{left.name}:#{right.name}"
+      )
+    end
+    findings
+  end
+
+  # --- check 4: informational metrics ---------------------------------------
+
+  def metrics
+    main = mainline
+    return [] if main.nil?
+
+    total = count_commits_since(main.ref)
+    return [] if total.zero?
+
+    merges = @repo.value('rev-list', '--count', '--merges', since_arg, main.ref).to_i
+    lifetimes = branch_lifetimes
+    lines = [
+      "Over the last #{WINDOW_MONTHS} months on #{main.name}: #{total} commits, #{merges} of " \
+      "them merges (#{(merges * 100.0 / total).round}%).",
+      "#{all_branches.length} branches currently exist."
+    ]
+    lines << lifetime_line(lifetimes) unless lifetimes.empty?
+    lines << "Maximum branches in flight at once: #{max_concurrent(lifetimes)}." unless lifetimes.empty?
+
+    [Finding.new(
+      rule_id: 'topology-metrics',
+      level: 'note',
+      message: lines.join(' '),
+      ref: main.name,
+      fingerprint: 'topology-metrics'
+    )]
+  end
+
+  def count_commits_since(ref)
+    @repo.value('rev-list', '--count', since_arg, ref).to_i
+  end
+
+  def lifetime_line(lifetimes)
+    days = lifetimes.map { |span| span[:days] }.sort
+    mean = (days.sum.to_f / days.length).round
+    p90 = days[(0.9 * (days.length - 1)).round]
+    "Branch lifetime across #{days.length} branches: mean #{mean} days, p90 #{p90} days."
+  end
+
+  # first commit since the merge base -> last commit, per branch
+  def branch_lifetimes
+    @branch_lifetimes ||= begin
+      main = mainline
+      spans = []
+      all_branches.each do |branch|
+        break if expired?
+        next if main.nil? || branch.ref == main.ref
+        # Same exclusions as check 1: a fleet of single-commit bot branches
+        # drags the mean to zero and describes the bot, not the workflow.
+        next if excluded?(branch.name) || INTEGRATION_CANDIDATES.include?(branch.name)
+
+        base = @repo.value('merge-base', main.ref, branch.ref)
+        next if base.nil?
+
+        stamps = @repo.lines('log', '--format=%ct', "#{base}..#{branch.ref}").map(&:to_i)
+        next if stamps.empty?
+
+        spans << { start: stamps.min, finish: stamps.max,
+                   days: ((stamps.max - stamps.min) / 86_400.0).floor }
+      end
+      spans
+    end
+  end
+
+  # Sweep line over [first commit, last commit] intervals.
+  def max_concurrent(lifetimes)
+    events = lifetimes.flat_map { |span| [[span[:start], 1], [span[:finish], -1]] }
+    # Close before open at the same instant, so a branch that ends exactly when
+    # another starts is not counted as concurrent.
+    events.sort_by! { |time, delta| [time, delta] }
+    running = 0
+    events.map { |_time, delta| running += delta }.max || 0
+  end
+end


### PR DESCRIPTION
Adds a `topology` analyser reporting on the health of the branching workflow rather than the code:
branches that never merge back, changes stranded on a release line, and merges that were expensive
because the branches were allowed to drift.

Strictly read-only — everything comes from `for-each-ref`, `rev-list`, `merge-base`, `diff` and
`patch-id`. It never checks out, merges, fetches, or touches the index.

## Squash detection is the load-bearing part

Ancestry alone reports every squash-merged branch as unmerged, and squash merges are the default on
most forges. The brief proposed `git cherry` as the fallback. I built a fixture to check it, and it
does not hold:

| Technique | Squash merge | Rebase merge |
|---|---|---|
| `merge-base --is-ancestor` | reports unmerged ✗ | reports unmerged ✗ |
| `git cherry` | **reports unmerged ✗** | correctly upstream ✓ |
| cumulative patch ID | **matches ✓** | doesn't match |

`git cherry` compares *per-commit* patch IDs. A squash collapses N commits into one whose patch ID
is the union diff, so no individual commit matches. It works for rebase and cherry-pick, where
per-commit patches survive.

So detection layers all three: ancestry → `git cherry` → the branch's cumulative diff patch ID
against mainline's commits. Only the third catches "Squash and merge". There are specs for the
squash and rebase cases specifically.

## Fixing a landmine in the renderer

`html_report.rb` dereferenced `locations[0].physical_location` with no guard. Feeding it a result
carrying only a `logicalLocation` produced:

```
CRASH: NoMethodError: undefined method `region' for nil
```

`statica` runs under `set -euo pipefail`, so one location-less result aborted the HTML step and took
**every other tool's findings with it**. Locations are now optional at every step, and
`GraphAnalyzer` leaves such findings as leaves under their analysis rather than inventing a file
node that would put a file nobody touched into the hotspot table.

This was worth fixing regardless of this PR — any future tool emitting a location-less result hit
the same landmine.

## SARIF mapping

- Overlap and size findings carry the **real overlapping paths**, so they flow into the hotspot
  table and the graph. A file that repeatedly appears in high-overlap merges *and* carries findings
  from other tools is the signal that justifies doing this inside Statica rather than standalone.
- Ref-scoped findings (checks 1 and 2) carry a `logicalLocation` and no synthetic
  `physicalLocation`.
- `partialFingerprints` key off the branch name or merge SHA, so triage survives re-runs. There is a
  spec asserting a new mainline commit does not re-open triage on a stale branch.
- Every rule has a stable `ruleId`, a `helpUri` anchoring into the README, and a `fullDescription`
  explaining why it matters.
- The `sarif` gem omits an empty results array, producing the `"results":null` shape that `statica`
  already special-cases for bearer. `sarif_json` emits an explicit `[]` so a findings-free run does
  not become a second instance of that bug.

## Defaults are tuned to stay quiet

Checked against two real repositories rather than guessed:

- **This repo**: 1 finding — the `graph` branch, abandoned 642 days ago — plus metrics. No merge
  findings.
- **WebGoat** (3220 commits): 9 findings, all branches between 1.5 and 4.5 years old. No merge
  findings. 2.5 seconds.

Two false-positive sources found during that tuning and fixed:

- `dependabot/*` and `renovate/*` are excluded. A lingering bot branch means a superseded PR and
  says nothing about the branching model; on this repo they were 6 of 8 findings.
- `refs/remotes/origin/HEAD` shortens to `origin`, so filtering on the short name let it through as
  a phantom branch. Now filtered on the full refname.

Also fixed: the "commits ahead" count was measured against mainline, so a branch that landed on
`main` but never reached `develop` reported "0 commits ahead" while being flagged as unmerged —
a contradiction on its face. It is now counted against a branch it is actually missing from.
Both have regression specs.

## Degrading

- **No `.git`** — the common case for source that arrived as an archive — contributes nothing and
  says nothing.
- **Shallow and partial clones** are skipped with one stderr diagnostic. Verified end to end: the
  acceptance workflow clones WebGoat with `--depth 1`, and this now emits
  `topology: history is shallow, topology checks skipped` plus a valid empty document that
  `sarif summary` reads as 0/0/0.
- Walks are bounded (12 months, 1000 merges, 500 branches) and the whole run abandons remaining work
  after 120 seconds, checked between checks as well as inside their loops.

## Testing

22 new specs building real fixture repositories in a temp dir, covering every case in the brief. The
false-positive cases are the ones that matter, so squash, rebase, cherry-pick, young branches, dead-
end prefixes, clean short-lived merges, shallow clones and no-`.git` all assert *absence*.

Full suite: 64 examples, 0 failures. `make test` passes end to end and the report renders topology
findings alongside every other tool.

## Dependencies

None. The analyser needs only `git`, already present in the Dockerfile and on any machine running
Statica, so neither the Dockerfile nor the Homebrew list changes. `topology_analyzer.rb` is added to
`spec.files` in the gemspec, without which the Homebrew install would ship the executable but not
the library.

## Not included

The revert-then-reapply stretch item is #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
